### PR TITLE
Make sure home activities is present

### DIFF
--- a/widgets.py
+++ b/widgets.py
@@ -25,6 +25,7 @@ from gettext import gettext as _
 from gi.repository import Gtk
 from gi.repository import GObject
 
+from sugar3 import env
 from sugar3.activity import activity
 from sugar3.graphics import style
 from sugar3.graphics.combobox import ComboBox
@@ -36,10 +37,15 @@ _EXCLUDE_EXTENSIONS = ('.pyc', '.pyo', '.so', '.o', '.a', '.la', '.mo', '~',
                        '.xo', '.tar', '.bz2', '.zip', '.gz')
 _EXCLUDE_NAMES = ['.deps', '.libs']
 
-try:
-    activities_path = os.environ['SUGAR_ACTIVITIES_PATH']
-except KeyError:
-    activities_path = os.path.join(os.path.expanduser("~"), "Activities")
+
+def _get_activities_path():
+    path = env.get_user_activities_path()
+    if not os.path.exists(path):
+        os.mkdir(path)
+    return path
+
+
+activities_path = _get_activities_path()
 
 
 class TabLabel(Gtk.HBox):


### PR DESCRIPTION
~/Activities is not present in all systems and this causes
the activity to break. Therefore, make sure it is present,
even if we have to create it ourselves.

Signed-off-by: Martin Abente Lahaye tch@sugarlabs.org
